### PR TITLE
Fix for TouchEvent problem

### DIFF
--- a/OsmSharp.Android.UI/MapView.cs
+++ b/OsmSharp.Android.UI/MapView.cs
@@ -470,11 +470,12 @@ namespace OsmSharp.Android.UI
             if (mapControl != null &&
                 mapControl.Handle != IntPtr.Zero)
             {
-                this.RemoveView(mapControl.BaseView);
-                if (mapControl.SetLayout(pixelsWidth, pixelsHeight, view, projection))
-                {
-                    this.AddView(mapControl.BaseView, mapControl.BaseView.LayoutParameters);
-                }
+                //this.RemoveView(mapControl.BaseView);
+                mapControl.SetLayout(pixelsWidth, pixelsHeight, view, projection);
+                //if (mapControl.SetLayout(pixelsWidth, pixelsHeight, view, projection))
+                //{
+                //    this.AddView(mapControl.BaseView, mapControl.BaseView.LayoutParameters);
+                //}
             }
         }
 


### PR DESCRIPTION
If a control or marker is touched simultaneously with the map surface tha application crashes.